### PR TITLE
ci/linting: removes golangci-lint as it repeatedly fails on first run due to runtime timeouts

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,16 +22,3 @@ jobs:
       - name: Unit Tests
         run: |
           make test build
-  linting:
-    name: lint
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.22'
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          version: v1.58


### PR DESCRIPTION
`golangci-lint` sounds cool but it keeps timing out on the first run.  Flapping tests are worse than no tests.